### PR TITLE
Add configurable keep_connected option

### DIFF
--- a/custom_components/neewer_ble/__init__.py
+++ b/custom_components/neewer_ble/__init__.py
@@ -23,6 +23,7 @@ from .const import (
     DEFAULT_COLOR_TEMP,
     CONF_DEFAULT_BRIGHTNESS,
     CONF_DEFAULT_COLOR_TEMP,
+    CONF_KEEP_CONNECTED,
 )
 from .neewer_device import NeewerLightDevice
 
@@ -61,20 +62,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Get options with defaults
     default_brightness = entry.options.get(CONF_DEFAULT_BRIGHTNESS, DEFAULT_BRIGHTNESS)
     default_color_temp = entry.options.get(CONF_DEFAULT_COLOR_TEMP, DEFAULT_COLOR_TEMP)
+    keep_connected = entry.options.get(CONF_KEEP_CONNECTED, False)
 
     # Create the device handler
     device = NeewerLightDevice(
         ble_device,
         default_brightness=default_brightness,
         default_color_temp=default_color_temp,
+        keep_connected=keep_connected,
     )
     _LOGGER.info(
-        "Created device handler - Model: %s, RGB: %s, Infinity: %s, Default Bri: %d, Default CT: %dK",
+        "Created device handler - Model: %s, RGB: %s, Infinity: %s, Default Bri: %d, Default CT: %dK, Keep Conn: %s",
         device.model_name,
         device.supports_rgb,
         device.uses_infinity_protocol,
         default_brightness,
         default_color_temp,
+        keep_connected,
     )
 
     # Store the device
@@ -98,13 +102,15 @@ async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
     default_brightness = entry.options.get(CONF_DEFAULT_BRIGHTNESS, DEFAULT_BRIGHTNESS)
     default_color_temp = entry.options.get(CONF_DEFAULT_COLOR_TEMP, DEFAULT_COLOR_TEMP)
+    keep_connected = entry.options.get(CONF_KEEP_CONNECTED, False)
 
-    device.set_defaults(default_brightness, default_color_temp)
+    device.set_defaults(default_brightness, default_color_temp, keep_connected)
     _LOGGER.info(
-        "Updated defaults for %s - Brightness: %d, Color Temp: %dK",
+        "Updated defaults for %s - Brightness: %d, Color Temp: %dK, Keep Conn: %s",
         device.name,
         default_brightness,
         default_color_temp,
+        keep_connected,
     )
 
 

--- a/custom_components/neewer_ble/config_flow.py
+++ b/custom_components/neewer_ble/config_flow.py
@@ -25,6 +25,7 @@ from .const import (
     DEFAULT_COLOR_TEMP,
     CONF_DEFAULT_BRIGHTNESS,
     CONF_DEFAULT_COLOR_TEMP,
+    CONF_KEEP_CONNECTED,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -225,6 +226,9 @@ class NeewerBLEOptionsFlow(config_entries.OptionsFlow):
         current_color_temp = self.config_entry.options.get(
             CONF_DEFAULT_COLOR_TEMP, DEFAULT_COLOR_TEMP
         )
+        current_keep_connected = self.config_entry.options.get(
+            CONF_KEEP_CONNECTED, False
+        )
 
         return self.async_show_form(
             step_id="init",
@@ -238,6 +242,10 @@ class NeewerBLEOptionsFlow(config_entries.OptionsFlow):
                         CONF_DEFAULT_COLOR_TEMP,
                         default=current_color_temp,
                     ): vol.All(vol.Coerce(int), vol.Range(min=2700, max=10000)),
+                    vol.Optional(
+                        CONF_KEEP_CONNECTED,
+                        default=current_keep_connected,
+                    ): bool,
                 }
             ),
         )

--- a/custom_components/neewer_ble/const.py
+++ b/custom_components/neewer_ble/const.py
@@ -70,6 +70,7 @@ DEFAULT_COLOR_TEMP = 3200
 # Options flow config keys
 CONF_DEFAULT_BRIGHTNESS = "default_brightness"
 CONF_DEFAULT_COLOR_TEMP = "default_color_temp"
+CONF_KEEP_CONNECTED = "keep_connected"
 
 # Color temperature conversion
 # Neewer uses a 0-100 scale internally for color temp

--- a/custom_components/neewer_ble/neewer_device.py
+++ b/custom_components/neewer_ble/neewer_device.py
@@ -52,6 +52,7 @@ class NeewerLightDevice:
         model_info: dict | None = None,
         default_brightness: int = 100,
         default_color_temp: int = 3200,
+        keep_connected: bool = False,
     ) -> None:
         """Initialize the Neewer light device."""
         self._ble_device = ble_device
@@ -70,6 +71,7 @@ class NeewerLightDevice:
         # Default values (configurable via options)
         self._default_brightness = default_brightness
         self._default_color_temp = default_color_temp
+        self._keep_connected = keep_connected
 
         # State - initialize to defaults
         self._is_on = False
@@ -346,7 +348,7 @@ class NeewerLightDevice:
             return False
         finally:
             # Always disconnect on error, or if not keeping connected
-            if not success or not keep_connected:
+            if not success or not (keep_connected or self._keep_connected):
                 await self.disconnect()
 
     def _build_cct_command(self, brightness: int, color_temp: int) -> list[int]:
@@ -597,6 +599,7 @@ class NeewerLightDevice:
         if not await self.connect():
             return None
 
+        success = False
         try:
             # Clear any previous notification data
             self._notify_data = None
@@ -620,6 +623,7 @@ class NeewerLightDevice:
             # Wait for notification response
             try:
                 await asyncio.wait_for(self._notify_event.wait(), timeout=timeout)
+                success = True
                 return self._notify_data
             except asyncio.TimeoutError:
                 _LOGGER.debug("Timeout waiting for response from %s", self._name)
@@ -636,7 +640,8 @@ class NeewerLightDevice:
             self._connected = False
             return None
         finally:
-            await self.disconnect()
+            if not success or not self._keep_connected:
+                await self.disconnect()
 
     async def async_get_power_status(self) -> bool | None:
         """Query the device power status.
@@ -722,15 +727,17 @@ class NeewerLightDevice:
         """Return True if the last poll was successful."""
         return self._last_poll_success
 
-    def set_defaults(self, brightness: int, color_temp_kelvin: int) -> None:
+    def set_defaults(self, brightness: int, color_temp_kelvin: int, keep_connected: bool = False) -> None:
         """Update default values (called when options change)."""
         self._default_brightness = brightness
         self._default_color_temp = color_temp_kelvin
+        self._keep_connected = keep_connected
         _LOGGER.debug(
-            "Updated defaults for %s: brightness=%d, color_temp=%dK",
+            "Updated defaults for %s: brightness=%d, color_temp=%dK, keep_connected=%s",
             self._name,
             brightness,
             color_temp_kelvin,
+            keep_connected,
         )
 
 

--- a/custom_components/neewer_ble/strings.json
+++ b/custom_components/neewer_ble/strings.json
@@ -40,7 +40,8 @@
         "description": "Configure default values for this light.",
         "data": {
           "default_brightness": "Default Brightness (1-100%)",
-          "default_color_temp": "Default Color Temperature (Kelvin)"
+          "default_color_temp": "Default Color Temperature (Kelvin)",
+          "keep_connected": "Keep Connection Active (Disable to allow Neewer app control)"
         }
       }
     }

--- a/custom_components/neewer_ble/translations/en.json
+++ b/custom_components/neewer_ble/translations/en.json
@@ -33,6 +33,19 @@
       "not_neewer_device": "This device does not appear to be a Neewer light."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Neewer Light Options",
+        "description": "Configure default values for this light.",
+        "data": {
+          "default_brightness": "Default Brightness (1-100%)",
+          "default_color_temp": "Default Color Temperature (Kelvin)",
+          "keep_connected": "Keep Connection Active (Disable to allow Neewer app control)"
+        }
+      }
+    }
+  },
   "entity": {
     "light": {
       "neewer_light": {


### PR DESCRIPTION
Allow users to configure whether the device stays connected after commands.

Useful for scenarios where users want faster response times and don't care about the Neewer app's connectivity.

Fixes #3. Fix generated by Gemini, but I'm always here to answer questions!