### PR TITLE
Fix color temperature calculation for non-standard CCT ranges

### DIFF
--- a/custom_components/neewer_ble/neewer_device.py
+++ b/custom_components/neewer_ble/neewer_device.py
@@ -361,8 +361,8 @@ class NeewerLightDevice:
             brightness: 0-100
             color_temp: 0-100 (internal scale, maps to kelvin range)
         """
-        # Convert 0-100 internal scale to 32-56 protocol temp value
-        temp_protocol = int(32 + (color_temp / 100) * 24)
+        # Convert 0-100 internal scale to protocol temp value (Kelvin / 100)
+        temp_protocol = int(self._internal_to_kelvin(color_temp) / 100)
         gm_value = 50  # Neutral green-magenta tint
 
         if self.light_type == 1:
@@ -446,8 +446,8 @@ class NeewerLightDevice:
         Args:
             color_temp: 0-100 (internal scale, maps to kelvin range)
         """
-        # Convert 0-100 internal scale to 32-56 protocol temp value
-        temp_protocol = int(32 + (color_temp / 100) * 24)
+        # Convert 0-100 internal scale to protocol temp value (Kelvin / 100)
+        temp_protocol = int(self._internal_to_kelvin(color_temp) / 100)
         cmd = [0x78, STD_TEMP_CMD, 0x01, temp_protocol]
         return self._add_checksum(cmd)
 


### PR DESCRIPTION
Instead of assuming a hardcoded 3200K-5600K range by mapping 0-100% directly to 32-56 protocol values, use the configured light color temp bounds. This dynamically converts the internal percentage to Kelvin, then scales it to the required protocol value (Kelvin/100). This fixes incorrect color temperatures on models with broader ranges like the CB100C.

Fix generated by Gemini, but I'm always here to answer questions!